### PR TITLE
Add bboss_global_search_filter_args filter

### DIFF
--- a/includes/class.BBoss_Global_Search_Helper.php
+++ b/includes/class.BBoss_Global_Search_Helper.php
@@ -315,6 +315,8 @@ if (!class_exists('BBoss_Global_Search_Helper')):
 				'template_type'		=> '',
 			);
 			
+			$args = apply_filters('bboss_global_search_filter_args', $args);
+			
 			$args = wp_parse_args( $args, $defaults );
 			
 			$this->search_args = $args;//save it for using in other methods


### PR DESCRIPTION
## Result

bboss_global_search_filter_args is the last chance that you have to filter the search results. 
This could be for anything from filtering user roles to excluding admins from search.

A use case for this would be something like this in your theme:

```
add_filter('bboss_global_search_filter_args', function($args) {
  $args = ['post__not_in' => 1];
  return $args;
});
```